### PR TITLE
Fixing bug present on Windows

### DIFF
--- a/oauth1/python-robot.py
+++ b/oauth1/python-robot.py
@@ -21,6 +21,7 @@ import json
 import os
 import sys
 import textwrap
+import urllib.parse
 
 APPLICATION_KEY = 'REDACTED'
 APPLICATION_SECRET = 'REDACTED'
@@ -38,7 +39,7 @@ oauth = requests_oauthlib.OAuth1(
 
 def _uri(path):
     """ Concatenates API_ENDPOINT and path """
-    return os.path.join(API_ENDPOINT, path.lstrip('/'))
+    return urllib.parse.urljoin(API_ENDPOINT, path.lstrip('/'))
 
 
 def _pretty_print_json(_obj):


### PR DESCRIPTION
Hi there,

I'm using this github repo as a jumping off point for one of my projects. There is one issue with the code at oauth1/python-robot.py on Windows. os.path.join on Windows uses \ to join two separate paths. This is due to how windows uses it to separate directories, unlike MacOS and Linux. This makes the urls come out like https://api.projectplace.com\1/account instead of  https://api.projectplace.com/1/account, for example. A quick fix for this would be to use urllib.parse.urljoin of the urllib.parse library instead of os.path.join. I have fixed that in this merge request.

I am using Windows 10, Python 3.11.5, requests 2.31.0, and requests_oauthlib 1.3.1.