### PR TITLE
Migrate examples from OAuth1 to OAuth2 client credentials

### DIFF
--- a/examples/node-js-import-cards-with-excel/Import_Cards_From_Xlsx.js
+++ b/examples/node-js-import-cards-with-excel/Import_Cards_From_Xlsx.js
@@ -21,7 +21,19 @@ function _ensureAccessToken() {
             form: { grant_type: 'client_credentials' }
         }, function(error, response, body) {
             if (error) return reject(error);
-            access_Token = JSON.parse(body).access_token;
+            if (!response || response.statusCode < 200 || response.statusCode >= 300) {
+                return reject(new Error(`Token request failed with status ${response && response.statusCode}: ${body}`));
+            }
+            let parsed;
+            try {
+                parsed = JSON.parse(body);
+            } catch (e) {
+                return reject(new Error(`Token response was not valid JSON: ${body}`));
+            }
+            if (!parsed.access_token) {
+                return reject(new Error(`Token response did not contain an access_token: ${body}`));
+            }
+            access_Token = parsed.access_token;
             resolve();
         });
     });

--- a/examples/node-js-import-cards-with-excel/Import_Cards_From_Xlsx.js
+++ b/examples/node-js-import-cards-with-excel/Import_Cards_From_Xlsx.js
@@ -2,20 +2,41 @@ const xlsx = require('node-xlsx');
 const request = require('request');
 const prompt = require('prompt-sync')();
 
-const access_Token = prompt("Please provide your API access token: ");
+const CLIENT_ID = 'REDACTED';
+const CLIENT_SECRET = 'REDACTED';
+const API_ENDPOINT = 'https://api.projectplace.com';
+
 const workspace_ID = prompt("Please provide the Workspace/Project ID where the Cards should appear in: ");
 const file_Path = prompt("Please provide the full path to the xlsx file: ");
 const work_Sheets = xlsx.parse(file_Path);
 
 var failed_ImportedCards = [];
+let access_Token = null;
 
-// Check how many Sheets there are in the xlsx file.
-if (work_Sheets.length > 1) {
-    console.warn("Found more than one sheet in the xlsx file.");
-    sheet_Name = prompt("Please provide the sheet name that the Cards are in: ");
-    handle_SheetInformation(get_SheetInformation(sheet_Name));
-} else {
-    handle_SheetInformation(work_Sheets[0]);
+function _ensureAccessToken() {
+    return new Promise((resolve, reject) => {
+        request.post({
+            url: `${API_ENDPOINT}/oauth2/access_token`,
+            auth: { user: CLIENT_ID, pass: CLIENT_SECRET },
+            form: { grant_type: 'client_credentials' }
+        }, function(error, response, body) {
+            if (error) return reject(error);
+            access_Token = JSON.parse(body).access_token;
+            resolve();
+        });
+    });
+}
+
+async function main() {
+    await _ensureAccessToken();
+
+    if (work_Sheets.length > 1) {
+        console.warn("Found more than one sheet in the xlsx file.");
+        const sheet_Name = prompt("Please provide the sheet name that the Cards are in: ");
+        handle_SheetInformation(get_SheetInformation(sheet_Name));
+    } else {
+        handle_SheetInformation(work_Sheets[0]);
+    }
 }
 
 function get_SheetInformation(sheetName) {
@@ -43,10 +64,10 @@ function handle_SheetInformation(sheet) {
             console.error("The headers / top row has an empty column in position: ",i+1);
             return false;
         }
-        userValue = sheet.data[0][i].toLowerCase();
+        const userValue = sheet.data[0][i].toLowerCase();
         userMappings[userValue] = i;
     }
-    
+
     // Remove the headers from the sheet data array so we only get the data for the Cards.
     sheet.data.splice(0,1);
 
@@ -66,7 +87,7 @@ function handle_SheetInformation(sheet) {
 
 }
 async function post_CreateCards(card_Information, userMappings) {
-    /* 
+    /*
     card_Information[y] = row
     card_Information[y][x] = in row y column x
     */
@@ -94,11 +115,11 @@ async function post_CreateCards(card_Information, userMappings) {
             // If the Card should be blocked then set the attribute "is blocked" to 1 (true).
             Card["is blocked"] = 1;
         }
-        // Create the array for the checklist 
+        // Create the array for the checklist
         let Card_CheckList = [];
         if (Card["checklist"] != undefined) {
             Card_CheckList = Card["checklist"].split("##");
-        } 
+        }
 
         userMappings_keys.forEach(Key => {
             if (Card[Key] == undefined) {
@@ -132,9 +153,9 @@ async function post_CreateCards(card_Information, userMappings) {
 
 async function send_Card(Card) {
     return new Promise(Information => {
-        request.post("https://api.projectplace.com/1/projects/"+workspace_ID+"/cards/create-new", {
+        request.post(`${API_ENDPOINT}/1/projects/${workspace_ID}/cards/create-new`, {
         auth: {
-         "bearer": access_Token.toString(),
+         "bearer": access_Token,
          "Content-Type": "application/json",
         },
         json: Card,
@@ -149,3 +170,5 @@ async function send_Card(Card) {
      });
     });
 }
+
+main();

--- a/examples/py-board-webhooks/board_subscription.py
+++ b/examples/py-board-webhooks/board_subscription.py
@@ -2,26 +2,44 @@ import json
 
 import argh
 import requests
-import requests_oauthlib
+import requests.auth
 
 
-APPLICATION_KEY = 'REDACTED'
-APPLICATION_SECRET = 'REDACTED'
-ACCESS_TOKEN_KEY = 'REDACTED'
-ACCESS_TOKEN_SECRET = 'REDACTED'
+CLIENT_ID = 'REDACTED'
+CLIENT_SECRET = 'REDACTED'
 API_ENDPOINT = 'https://api.projectplace.com'
 
-oauth1 = requests_oauthlib.OAuth1(
-    client_key=APPLICATION_KEY,
-    client_secret=APPLICATION_SECRET,
-    resource_owner_key=ACCESS_TOKEN_KEY,
-    resource_owner_secret=ACCESS_TOKEN_SECRET
-)
+access_token = None
+
+
+def _ensure_access_token():
+    """
+    We ask for a new access token on every script run - in normal circumstances you can hold on to an access
+    token for longer than that.
+
+    This function uses the client credentials flow which only works for robot accounts since it is intended for
+    application-to-application communication. So the client_id and client_secret needs to belong to a robot and the
+    resulting access token will also belong to the robot.
+    """
+    global access_token
+    access_token_response = requests.post(
+        f'{API_ENDPOINT}/oauth2/access_token',
+        data={
+            'grant_type': 'client_credentials',
+        },
+        auth=requests.auth.HTTPBasicAuth(CLIENT_ID, CLIENT_SECRET)
+    )
+    access_token_response.raise_for_status()
+    access_token = access_token_response.json()['access_token']
+
+
+def _get_auth_header():
+    return {'Authorization': f'Bearer {access_token}'}
 
 
 def _board_is_accessible(board_id):
     r = requests.get(
-        f'{API_ENDPOINT}/1/boards/{board_id}', auth=oauth1
+        f'{API_ENDPOINT}/1/boards/{board_id}', headers=_get_auth_header()
     )
 
     if r.status_code == 200:
@@ -33,7 +51,7 @@ def _board_is_accessible(board_id):
 def _subscribe_to_board(board_id, project_id, webhook_url):
     existing_webhooks = requests.get(
         f'{API_ENDPOINT}/1/webhooks/list',
-        auth=oauth1
+        headers=_get_auth_header()
     ).json()
 
     for webhook in existing_webhooks:
@@ -46,7 +64,7 @@ def _subscribe_to_board(board_id, project_id, webhook_url):
                         'event_type': ['card_status_change'],
                         'webhook': webhook_url
                     },
-                    auth=oauth1
+                    headers=_get_auth_header()
                 )
             return webhook
 
@@ -59,7 +77,7 @@ def _subscribe_to_board(board_id, project_id, webhook_url):
             'project_id': project_id,
             'webhook': webhook_url
         },
-        auth=oauth1
+        headers=_get_auth_header()
     ).json()
 
 
@@ -72,14 +90,14 @@ def _unsubscribe_to_board(board_id):
     if subscription_to_delete:
         requests.delete(
             f'{API_ENDPOINT}/1/webhooks/{subscription_to_delete["id"]}',
-            auth=oauth1
+            headers=_get_auth_header()
         )
 
 
 def _report_subscription_status(board_id):
     r = requests.get(
         f'{API_ENDPOINT}/1/webhooks/list',
-        auth=oauth1
+        headers=_get_auth_header()
     )
 
     if r.status_code != 200:
@@ -99,9 +117,10 @@ def _report_subscription_status(board_id):
                                                   'invoked when the subscribed event happens')
 @argh.arg('-u', '--unsubscribe', default=False, help='Delete the subscription if it exists')
 def board_subscription(board_id, *, webhook_url='', unsubscribe=False):
+    _ensure_access_token()
     project_id = _board_is_accessible(board_id)
     if not project_id:
-        print(f'Board does not exist or is not accessible using {oauth1.client}')
+        print('Board does not exist or is not accessible with the current credentials')
         exit(1)
 
     if webhook_url:

--- a/examples/py-board-webhooks/requirements.txt
+++ b/examples/py-board-webhooks/requirements.txt
@@ -1,3 +1,2 @@
 argh
 requests
-requests_oauthlib

--- a/examples/py-bulk-update-emails/bulk_update_account_emails.py
+++ b/examples/py-bulk-update-emails/bulk_update_account_emails.py
@@ -2,22 +2,39 @@ import csv
 import json
 import argh
 import requests
-import requests_oauthlib
+import requests.auth
 
 
-APPLICATION_KEY = 'REDACTED'
-APPLICATION_SECRET = 'REDACTED'
-ACCESS_TOKEN_KEY = 'REDACTED'
-ACCESS_TOKEN_SECRET = 'REDACTED'
+CLIENT_ID = 'REDACTED'
+CLIENT_SECRET = 'REDACTED'
 API_ENDPOINT = 'https://api.projectplace.com'
 
+access_token = None
 
-oauth1 = requests_oauthlib.OAuth1(
-    client_key=APPLICATION_KEY,
-    client_secret=APPLICATION_SECRET,
-    resource_owner_key=ACCESS_TOKEN_KEY,
-    resource_owner_secret=ACCESS_TOKEN_SECRET
-)
+
+def _ensure_access_token():
+    """
+    We ask for a new access token on every script run - in normal circumstances you can hold on to an access
+    token for longer than that.
+
+    This function uses the client credentials flow which only works for robot accounts since it is intended for
+    application-to-application communication. So the client_id and client_secret needs to belong to a robot and the
+    resulting access token will also belong to the robot.
+    """
+    global access_token
+    access_token_response = requests.post(
+        f'{API_ENDPOINT}/oauth2/access_token',
+        data={
+            'grant_type': 'client_credentials',
+        },
+        auth=requests.auth.HTTPBasicAuth(CLIENT_ID, CLIENT_SECRET)
+    )
+    access_token_response.raise_for_status()
+    access_token = access_token_response.json()['access_token']
+
+
+def _get_auth_header():
+    return {'Authorization': f'Bearer {access_token}'}
 
 
 def get_email_changes(csv_file):
@@ -37,7 +54,7 @@ def get_valid_email_changes(existing_emails):
     Compare the list of existing emails to emails of actual account members. Return a mapping where
     only account members are represented.
     """
-    response = requests.get(f'{API_ENDPOINT}/1/account/people', auth=oauth1)
+    response = requests.get(f'{API_ENDPOINT}/1/account/people', headers=_get_auth_header())
 
     assert response.status_code == 200
 
@@ -62,7 +79,7 @@ def change_emails(emails_to_change):
         r = requests.post(
             f'{API_ENDPOINT}/1/account/people/{new["id"]}',
             json={'action': 'add_secondary_email', 'params': [new['email']]},
-            auth=oauth1
+            headers=_get_auth_header()
         )
         if r.status_code != 200:
             failures.append(existing)
@@ -77,6 +94,7 @@ def change_emails(emails_to_change):
 
 
 def bulk_update_emails(csv_file):
+    _ensure_access_token()
     email_changes = get_email_changes(csv_file)
 
     all_mapped_account_members = get_valid_email_changes(email_changes)

--- a/examples/py-bulk-update-emails/requirements.txt
+++ b/examples/py-bulk-update-emails/requirements.txt
@@ -1,3 +1,2 @@
 argh
 requests
-requests_oauthlib

--- a/examples/py-download-archived-workspaces/download_workspaces.py
+++ b/examples/py-download-archived-workspaces/download_workspaces.py
@@ -2,22 +2,39 @@ import math
 import os.path
 import argh
 import requests
-import requests_oauthlib
+import requests.auth
 
 
-APPLICATION_KEY = 'REDACTED'
-APPLICATION_SECRET = 'REDACTED'
-ACCESS_TOKEN_KEY = 'REDACTED'
-ACCESS_TOKEN_SECRET = 'REDACTED'
+CLIENT_ID = 'REDACTED'
+CLIENT_SECRET = 'REDACTED'
 API_ENDPOINT = 'https://api.projectplace.com'
 
+access_token = None
 
-oauth1 = requests_oauthlib.OAuth1(
-    client_key=APPLICATION_KEY,
-    client_secret=APPLICATION_SECRET,
-    resource_owner_key=ACCESS_TOKEN_KEY,
-    resource_owner_secret=ACCESS_TOKEN_SECRET
-)
+
+def _ensure_access_token():
+    """
+    We ask for a new access token on every script run - in normal circumstances you can hold on to an access
+    token for longer than that.
+
+    This function uses the client credentials flow which only works for robot accounts since it is intended for
+    application-to-application communication. So the client_id and client_secret needs to belong to a robot and the
+    resulting access token will also belong to the robot.
+    """
+    global access_token
+    access_token_response = requests.post(
+        f'{API_ENDPOINT}/oauth2/access_token',
+        data={
+            'grant_type': 'client_credentials',
+        },
+        auth=requests.auth.HTTPBasicAuth(CLIENT_ID, CLIENT_SECRET)
+    )
+    access_token_response.raise_for_status()
+    access_token = access_token_response.json()['access_token']
+
+
+def _get_auth_header():
+    return {'Authorization': f'Bearer {access_token}'}
 
 
 class ProjectToDownload:
@@ -54,7 +71,7 @@ def _fetch_archived_projects_info(limit=100, row_number=0):
     if row_number:
         request_body.update({'row_number': row_number})
 
-    r = requests.post(f'{API_ENDPOINT}/2/account/projects', json=request_body, auth=oauth1)
+    r = requests.post(f'{API_ENDPOINT}/2/account/projects', json=request_body, headers=_get_auth_header())
 
     response_json = r.json()
 
@@ -131,7 +148,7 @@ def _trigger_project_export(project_id: int):
               "include_plan_attachments": True, "include_boards": True, "include_card_attachments": True,
               "include_archived_boards": True, "include_conversations": True, "include_conversation_attachments": True,
               "include_issues_2": True, "include_issues_2_attachments": True},
-        auth=oauth1
+        headers=_get_auth_header()
     )
     response.raise_for_status()
     if response.status_code == 200:
@@ -164,7 +181,7 @@ def _await_export(project_id, export_id):
     while not export_done:
         time.sleep(5)
         export_result = requests.get(
-            f'{API_ENDPOINT}/1/projects/{project_id}/exports/{export_id}', auth=oauth1
+            f'{API_ENDPOINT}/1/projects/{project_id}/exports/{export_id}', headers=_get_auth_header()
         )
 
         if not export_result.status_code == 200:
@@ -186,7 +203,7 @@ def _download_export(project_id, download_name, download_uri, path=None):
     if path is not None:
         file_path = os.path.join(path, file_path)
 
-    with requests.get(download_uri, auth=oauth1, stream=True) as r:
+    with requests.get(download_uri, headers=_get_auth_header(), stream=True) as r:
         r.raise_for_status()
         with open(file_path, 'wb') as fp:
             for chunk in r.iter_content(chunk_size=2097152):  # 2 MB chunks should be fine
@@ -209,7 +226,7 @@ def _delete_archived_projects(archived_projects, path=None):
             continue
 
         r = requests.delete(
-            f'{API_ENDPOINT}/1/projects/{archived_project.id}', auth=oauth1
+            f'{API_ENDPOINT}/1/projects/{archived_project.id}', headers=_get_auth_header()
         )
         if r.status_code != 200:
             print(f'{n}/{total_count} Failed to delete {archived_project.id} - {archived_project.name}')
@@ -230,6 +247,7 @@ def download_archived_projects(*, purge_after_download=False, path=None):
     """
     This is the entry point of the script.
     """
+    _ensure_access_token()
     if path is not None:
         assert os.path.isdir(path) is True  # Abort if path is not a valid directory
 

--- a/examples/py-download-archived-workspaces/requirements.txt
+++ b/examples/py-download-archived-workspaces/requirements.txt
@@ -1,3 +1,2 @@
 argh
 requests
-requests_oauthlib

--- a/examples/py-download-document/download_document.py
+++ b/examples/py-download-document/download_document.py
@@ -2,29 +2,46 @@ import os.path
 import urllib.parse
 import argh
 import requests
-import requests_oauthlib
+import requests.auth
 
 
-APPLICATION_KEY = 'REDACTED'
-APPLICATION_SECRET = 'REDACTED'
-ACCESS_TOKEN_KEY = 'REDACTED'
-ACCESS_TOKEN_SECRET = 'REDACTED'
+CLIENT_ID = 'REDACTED'
+CLIENT_SECRET = 'REDACTED'
 API_ENDPOINT = 'https://api.projectplace.com'
 
+access_token = None
 
-oauth1 = requests_oauthlib.OAuth1(
-    client_key=APPLICATION_KEY,
-    client_secret=APPLICATION_SECRET,
-    resource_owner_key=ACCESS_TOKEN_KEY,
-    resource_owner_secret=ACCESS_TOKEN_SECRET
-)
+
+def _ensure_access_token():
+    """
+    We ask for a new access token on every script run - in normal circumstances you can hold on to an access
+    token for longer than that.
+
+    This function uses the client credentials flow which only works for robot accounts since it is intended for
+    application-to-application communication. So the client_id and client_secret needs to belong to a robot and the
+    resulting access token will also belong to the robot.
+    """
+    global access_token
+    access_token_response = requests.post(
+        f'{API_ENDPOINT}/oauth2/access_token',
+        data={
+            'grant_type': 'client_credentials',
+        },
+        auth=requests.auth.HTTPBasicAuth(CLIENT_ID, CLIENT_SECRET)
+    )
+    access_token_response.raise_for_status()
+    access_token = access_token_response.json()['access_token']
+
+
+def _get_auth_header():
+    return {'Authorization': f'Bearer {access_token}'}
 
 
 def _choose_workspace():
     """
     Asks the user to pick a workspace - and returns the ID of the selected workspace if it is valid
     """
-    available_workspaces = requests.get(f'{API_ENDPOINT}/1/user/me/projects', auth=oauth1).json()
+    available_workspaces = requests.get(f'{API_ENDPOINT}/1/user/me/projects', headers=_get_auth_header()).json()
 
     print('\nYou have access to the following workspaces:')
 
@@ -47,7 +64,7 @@ def _download_document(document):
     # not contain any forbidden characters - but is urlencoded so we unquote it.
     filename = urllib.parse.unquote(document['os_file_name'])
     print('Downloading...')
-    with requests.get(f'{API_ENDPOINT}/1/documents/{document["id"]}', auth=oauth1, stream=True) as r:
+    with requests.get(f'{API_ENDPOINT}/1/documents/{document["id"]}', headers=_get_auth_header(), stream=True) as r:
         r.raise_for_status()
         with open(filename, 'wb') as fp:
             for chunk in r.iter_content(chunk_size=8192):
@@ -61,7 +78,7 @@ def _get_document_container_contents(document_container_id):
     """
 
     # The actual contents of the document container is found in the "contents" attribute
-    contents = requests.get(f'{API_ENDPOINT}/2/documents/{document_container_id}', auth=oauth1).json()['contents']
+    contents = requests.get(f'{API_ENDPOINT}/2/documents/{document_container_id}', headers=_get_auth_header()).json()['contents']
 
     folders = []
     documents = []
@@ -97,6 +114,7 @@ def _get_document_container_contents(document_container_id):
 
 @argh.arg('-d', '--document-id', type=int, default=None)
 def main(*, document_id=None):
+    _ensure_access_token()
 
     if document_id is None:
         # Step 1 - which workspace should we list documents for?
@@ -105,7 +123,7 @@ def main(*, document_id=None):
         # Step 2 - Ask the user to designate which document to download
         _get_document_container_contents(workspace_id)
     else:
-        document = requests.get(f'{API_ENDPOINT}/2/documents/{document_id}', auth=oauth1).json()
+        document = requests.get(f'{API_ENDPOINT}/2/documents/{document_id}', headers=_get_auth_header()).json()
 
         _download_document(document)
 

--- a/examples/py-download-document/requirements.txt
+++ b/examples/py-download-document/requirements.txt
@@ -1,3 +1,2 @@
 requests
-requests_oauthlib
 argh

--- a/examples/py-list-document-archive/list_document_archive.py
+++ b/examples/py-list-document-archive/list_document_archive.py
@@ -2,28 +2,45 @@ import datetime
 import json
 import os.path
 import requests
-import requests_oauthlib
+import requests.auth
 
-APPLICATION_KEY = 'REDACTED'
-APPLICATION_SECRET = 'REDACTED'
-ACCESS_TOKEN_KEY = 'REDACTED'
-ACCESS_TOKEN_SECRET = 'REDACTED'
+CLIENT_ID = 'REDACTED'
+CLIENT_SECRET = 'REDACTED'
 API_ENDPOINT = 'https://api.projectplace.com'
 
+access_token = None
 
-oauth1 = requests_oauthlib.OAuth1(
-    client_key=APPLICATION_KEY,
-    client_secret=APPLICATION_SECRET,
-    resource_owner_key=ACCESS_TOKEN_KEY,
-    resource_owner_secret=ACCESS_TOKEN_SECRET
-)
+
+def _ensure_access_token():
+    """
+    We ask for a new access token on every script run - in normal circumstances you can hold on to an access
+    token for longer than that.
+
+    This function uses the client credentials flow which only works for robot accounts since it is intended for
+    application-to-application communication. So the client_id and client_secret needs to belong to a robot and the
+    resulting access token will also belong to the robot.
+    """
+    global access_token
+    access_token_response = requests.post(
+        f'{API_ENDPOINT}/oauth2/access_token',
+        data={
+            'grant_type': 'client_credentials',
+        },
+        auth=requests.auth.HTTPBasicAuth(CLIENT_ID, CLIENT_SECRET)
+    )
+    access_token_response.raise_for_status()
+    access_token = access_token_response.json()['access_token']
+
+
+def _get_auth_header():
+    return {'Authorization': f'Bearer {access_token}'}
 
 
 def _choose_workspace():
     """
     Asks the user to pick a workspace - and returns the ID of the selected workspace if it is valid
     """
-    available_workspaces = requests.get(f'{API_ENDPOINT}/1/user/me/projects', auth=oauth1).json()
+    available_workspaces = requests.get(f'{API_ENDPOINT}/1/user/me/projects', headers=_get_auth_header()).json()
 
     print('\nYou have access to the following workspaces:')
 
@@ -44,7 +61,7 @@ def _get_document_container_contents(workspace_id):
     """
     Returns the contents of the root of a workspace document container
     """
-    return requests.get(f'{API_ENDPOINT}/2/documents/{workspace_id}', auth=oauth1).json()
+    return requests.get(f'{API_ENDPOINT}/2/documents/{workspace_id}', headers=_get_auth_header()).json()
 
 
 def _save_to_file(workspace_id, document_archive_root_contents):
@@ -59,6 +76,7 @@ def _save_to_file(workspace_id, document_archive_root_contents):
 
 
 def main():
+    _ensure_access_token()
     # Step 1 - which workspace should we list documents for?
     workspace_id = _choose_workspace()
 

--- a/examples/py-list-document-archive/requirements.txt
+++ b/examples/py-list-document-archive/requirements.txt
@@ -1,2 +1,1 @@
 requests
-requests-oauthlib

--- a/examples/py-remove-inactive-users/remove_inactive_users.py
+++ b/examples/py-remove-inactive-users/remove_inactive_users.py
@@ -1,21 +1,39 @@
 import collections
 import datetime
 import requests
-import requests_oauthlib
+import requests.auth
 import argh
 
-APPLICATION_KEY = 'REDACTED'
-APPLICATION_SECRET = 'REDACTED'
-ACCESS_TOKEN_KEY = 'REDACTED'
-ACCESS_TOKEN_SECRET = 'REDACTED'
+CLIENT_ID = 'REDACTED'
+CLIENT_SECRET = 'REDACTED'
 API_ENDPOINT = 'https://api.projectplace.com'
 
-oauth1 = requests_oauthlib.OAuth1(
-    client_key=APPLICATION_KEY,
-    client_secret=APPLICATION_SECRET,
-    resource_owner_key=ACCESS_TOKEN_KEY,
-    resource_owner_secret=ACCESS_TOKEN_SECRET
-)
+access_token = None
+
+
+def _ensure_access_token():
+    """
+    We ask for a new access token on every script run - in normal circumstances you can hold on to an access
+    token for longer than that.
+
+    This function uses the client credentials flow which only works for robot accounts since it is intended for
+    application-to-application communication. So the client_id and client_secret needs to belong to a robot and the
+    resulting access token will also belong to the robot.
+    """
+    global access_token
+    access_token_response = requests.post(
+        f'{API_ENDPOINT}/oauth2/access_token',
+        data={
+            'grant_type': 'client_credentials',
+        },
+        auth=requests.auth.HTTPBasicAuth(CLIENT_ID, CLIENT_SECRET)
+    )
+    access_token_response.raise_for_status()
+    access_token = access_token_response.json()['access_token']
+
+
+def _get_auth_header():
+    return {'Authorization': f'Bearer {access_token}'}
 
 
 def get_inactive_users(days):
@@ -44,7 +62,7 @@ def get_inactive_users(days):
             'limit': 40,
             'row_number': 0
         },
-        auth=oauth1).json()
+        headers=_get_auth_header()).json()
 
     return inactive_users
 
@@ -71,7 +89,7 @@ def verify_replace_with(replace_with_id, inactive_users):
         return False
 
     all_account_members = requests.get(
-        f'{API_ENDPOINT}/1/account/people', auth=oauth1
+        f'{API_ENDPOINT}/1/account/people', headers=_get_auth_header()
     ).json()
 
     all_account_member_ids = [int(u['id']) for u in all_account_members if u['account_role'] in (
@@ -133,7 +151,7 @@ def organise_owner_transfers(inactive_users):
         owner_record['is_external'] = user_to_remove['account_role'] == 'account_role_external'
         owned_artifacts = requests.get(
             f'{API_ENDPOINT}/1/account/people/{user_to_remove["userid"]}/owned-artifacts',
-            auth=oauth1
+            headers=_get_auth_header()
         ).json()
 
         # 1. Workspaces
@@ -166,7 +184,7 @@ def _remove_account_user(user_id):
                 }
             ]
         },
-        auth=oauth1
+        headers=_get_auth_header()
     )
     response.raise_for_status()
     try:
@@ -205,7 +223,7 @@ def _delete_account_user(user_id, ownerships=None, replace_with=None):
                 ownerships_payload
             ]
         },
-        auth=oauth1
+        headers=_get_auth_header()
     )
 
     response.raise_for_status()
@@ -269,6 +287,7 @@ def execute_removal(owner_transfers, replace_with):
 @argh.arg('replace-with', type=int,
           help='Specify the ID of a person who should take over the head admin roles of whoever gets deleted')
 def main(days: int, replace_with: int):
+    _ensure_access_token()
     inactive_users = get_inactive_users(days)
 
     if not inactive_users:

--- a/examples/py-remove-inactive-users/requirements.txt
+++ b/examples/py-remove-inactive-users/requirements.txt
@@ -1,3 +1,2 @@
 requests
-requests_oauthlib
 argh

--- a/examples/py-upload-document/requirements.txt
+++ b/examples/py-upload-document/requirements.txt
@@ -1,3 +1,2 @@
 argh
 requests
-requests_oauthlib

--- a/examples/py-upload-document/upload_document.py
+++ b/examples/py-upload-document/upload_document.py
@@ -2,23 +2,39 @@ import json
 import os.path
 import argh
 import requests
-import requests_oauthlib
+import requests.auth
 
 
+CLIENT_ID = 'REDACTED'
+CLIENT_SECRET = 'REDACTED'
+API_ENDPOINT = 'https://api.projectplace.com'
 
-APPLICATION_KEY = '65a7b8a09cad1c8a514968d3ae0dcea4'
-APPLICATION_SECRET = 'baf74123d0897cc61652d7b458638ad12791160f'
-ACCESS_TOKEN_KEY = '04b12136a5093ac378304449171d83a4'
-ACCESS_TOKEN_SECRET = '448ed69b90659cd97c3a5b6e99a6651682b0ced7'
-API_ENDPOINT = 'https://api-compose.rnd.projectplace.com'
+access_token = None
 
 
-oauth1 = requests_oauthlib.OAuth1(
-    client_key=APPLICATION_KEY,
-    client_secret=APPLICATION_SECRET,
-    resource_owner_key=ACCESS_TOKEN_KEY,
-    resource_owner_secret=ACCESS_TOKEN_SECRET
-)
+def _ensure_access_token():
+    """
+    We ask for a new access token on every script run - in normal circumstances you can hold on to an access
+    token for longer than that.
+
+    This function uses the client credentials flow which only works for robot accounts since it is intended for
+    application-to-application communication. So the client_id and client_secret needs to belong to a robot and the
+    resulting access token will also belong to the robot.
+    """
+    global access_token
+    access_token_response = requests.post(
+        f'{API_ENDPOINT}/oauth2/access_token',
+        data={
+            'grant_type': 'client_credentials',
+        },
+        auth=requests.auth.HTTPBasicAuth(CLIENT_ID, CLIENT_SECRET)
+    )
+    access_token_response.raise_for_status()
+    access_token = access_token_response.json()['access_token']
+
+
+def _get_auth_header():
+    return {'Authorization': f'Bearer {access_token}'}
 
 
 def _choose_workspace():
@@ -26,7 +42,7 @@ def _choose_workspace():
     Asks the user to pick a workspace - and returns the ID of the selected workspace's main document
      container - if it is valid
     """
-    available_workspaces = requests.get(f'{API_ENDPOINT}/1/user/me/projects?include_tools=true', auth=oauth1).json()
+    available_workspaces = requests.get(f'{API_ENDPOINT}/1/user/me/projects?include_tools=true', headers=_get_auth_header()).json()
     print('You have access to the following workspaces:')
     for workspace in available_workspaces:
         print(f'{workspace["name"]} ID: {workspace["id"]}')
@@ -47,14 +63,14 @@ def _do_the_upload(file_path, document_container_id):
     r = requests.post(
         f'{API_ENDPOINT}/2/documents/{document_container_id}/upload',
         files={file_name: open(file_path, 'rb')},
-        auth=oauth1
+        headers=_get_auth_header()
     )
 
     return r.json()['id'], r.json()['ver_nr']
 
 
 def _verify_container(container_id):
-    r = requests.get(f'{API_ENDPOINT}/2/documents/{container_id}', auth=oauth1)
+    r = requests.get(f'{API_ENDPOINT}/2/documents/{container_id}', headers=_get_auth_header())
     response_json = r.json()
 
     if 'container_id' not in response_json:
@@ -70,6 +86,7 @@ def _verify_container(container_id):
 @argh.arg('file_path')
 @argh.arg('-f', '--folder-id', type=int, default=None)
 def upload_document(file_path, *, folder_id=None):
+    _ensure_access_token()
     if not os.path.isfile(file_path):
         print(file_path, 'doesn\'t seem to be a valid file')
         exit(1)
@@ -81,9 +98,9 @@ def upload_document(file_path, *, folder_id=None):
     document_id, version_number = _do_the_upload(file_path, document_container_id)
 
     if not version_number:
-        print('Document isn\'t in a versioned container - so a new document has been created:', f'https://compose.rnd.projectplace.com/pp/pp.cgi/r{document_id}')
+        print('Document isn\'t in a versioned container - so a new document has been created:', f'https://www.projectplace.com/pp/pp.cgi/r{document_id}')
     else:
-        print('New version', version_number, 'of document has been uploaded:', f'https://compose.rnd.projectplace.com/pp/pp.cgi/r{document_id}')
+        print('New version', version_number, 'of document has been uploaded:', f'https://www.projectplace.com/pp/pp.cgi/r{document_id}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Replace OAuth1 (APPLICATION_KEY/SECRET + ACCESS_TOKEN_KEY/SECRET) with OAuth2 client credentials flow (CLIENT_ID/SECRET) across all Python examples
- Add _ensure_access_token() and _get_auth_header() helpers to each script, matching the pattern established in auth/py-oauth2-client-credentials/
- Migrate node-js-import-cards-with-excel from manual token prompt to automated client credentials fetch
- Remove requests_oauthlib from all requirements.txt files
- Redact real credentials and fix dev API endpoint in py-upload-document

https://planview.projectplace.com/#direct/card/29226320